### PR TITLE
Add an about page to the DigitalKit application.

### DIFF
--- a/FrontEnd/digitalkit/app/about.tsx
+++ b/FrontEnd/digitalkit/app/about.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AboutPage: React.FC = () => {
+  return (
+    <div>
+      <h1>About DigitalKit</h1>
+      <p>DigitalKit is an application designed to help users understand and experiment with digital logic circuits. It provides a virtual environment for designing, simulating, and verifying the behavior of various integrated circuits (ICs).</p>
+    </div>
+  );
+};
+
+export default AboutPage;

--- a/FrontEnd/digitalkit/app/layout.tsx
+++ b/FrontEnd/digitalkit/app/layout.tsx
@@ -27,6 +27,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <nav>
+          <a href="/">Home</a> | <a href="/about">About</a>
+        </nav>
         {children}
       </body>
     </html>


### PR DESCRIPTION
This commit introduces a new `/about` page that provides you with information about the DigitalKit application.

Key changes:
- Created `FrontEnd/digitalkit/app/about.tsx` with a heading and a descriptive paragraph.
- Updated `FrontEnd/digitalkit/app/layout.tsx` to include a simple navigation bar with links to the Home and About pages.