### PR TITLE
Remove graph from ICVisualizer and add CLOCK:PULSE button

### DIFF
--- a/FrontEnd/digitalkit/app/components/SerialPortInterface.tsx
+++ b/FrontEnd/digitalkit/app/components/SerialPortInterface.tsx
@@ -1137,6 +1137,13 @@ export default function SerialPortInterface({
             >
               Show Buffer
             </button>
+            <button
+              onClick={() => sendData("CLOCK:PULSE\n")}
+              disabled={!isConnected}
+              className="px-4 py-2 text-sm bg-teal-700 text-teal-100 rounded-md hover:bg-teal-600 dark:bg-teal-900 dark:text-teal-100 dark:hover:bg-teal-800 disabled:opacity-50"
+            >
+              Send CLOCK:PULSE
+            </button>
           </div>
         </div>
 


### PR DESCRIPTION
- Removed the recharts graph from the ICVisualizer component in full-screen mode.
- Deleted associated state and logic for pin history tracking.
- Added a new button to the SerialPortInterface to send "CLOCK:PULSE\n" command to the connected serial device.
- The button is located in the Debug Log section and is disabled when not connected.